### PR TITLE
Specify actual path in 'mkdir' task name

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 # tasks file for tmux-tpm
-- name: mkdir ~/.tmux/plugins
+- name: mkdir {{tmux_tpm_plugins_path}}
   file:
     path: "{{tmux_tpm_plugins_path}}"
     state: directory


### PR DESCRIPTION
The actual path - which is configurable via the `tmux_tpm_plugins_path` variable - should be used in the name of the 'mkdir' task instead of a default that's not necessarily being used.